### PR TITLE
Upgrade to 2.8.0 & remove reflection warnings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.curator/curator-recipes "2.4.2"]
-                 [org.apache.curator/curator-framework "2.4.2"]
-                 [org.apache.curator/curator-x-discovery "2.4.2"]]
-  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.6.4"]
-                                  [org.slf4j/slf4j-simple "1.6.4"]]
+                 [org.apache.curator/curator-recipes "2.8.0"]
+                 [org.apache.curator/curator-framework "2.8.0"]
+                 [org.apache.curator/curator-x-discovery "2.8.0"]]
+  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.12"]
+                                  [org.slf4j/slf4j-simple "1.7.12"]]
                    :exclusions [org.slf4j/slf4j-log4j12]}}
   :scm {:name "git"
         :url "https://github.com/pingles/curator"})

--- a/src/curator/framework.clj
+++ b/src/curator/framework.clj
@@ -7,7 +7,7 @@
 (defn exponential-retry [sleep-millis num-retries]
   (ExponentialBackoffRetry. sleep-millis num-retries))
 
-(defn curator-framework
+(defn ^CuratorFramework curator-framework
   [connect-string & {:keys [retry-policy connect-timeout-millis session-timeout-millis namespace]
                      :or   {retry-policy           (exponential-retry 1000 10)
                             connect-timeout-millis 500

--- a/src/curator/leader.clj
+++ b/src/curator/leader.clj
@@ -1,6 +1,6 @@
 (ns curator.leader
   (:require [curator.framework :refer (time-units)])
-  (:import [org.apache.curator.framework.recipes.leader LeaderSelector LeaderSelectorListener CancelLeadershipException LeaderLatch]
+  (:import [org.apache.curator.framework.recipes.leader LeaderSelector LeaderSelectorListener CancelLeadershipException]
            [org.apache.curator.framework.state ConnectionState]
            [java.util UUID]))
 
@@ -16,7 +16,7 @@
              (finally
                (throw (CancelLeadershipException.))))))))
 
-(defn leader-selector
+(defn ^LeaderSelector leader-selector
   "Creates a Leader Selector.
    path: The path in ZooKeeper for storing this leadership group
    leaderfn: Function that will be called when the current process becomes
@@ -25,9 +25,9 @@
    losingfn: Optional function that will be called when the connection state
       changes indicating we're going to lose leadership.
    participant-id: Uniquely identifies this participant. Defaults to UUID/randomUUID"
-  [curator-framework path leaderfn & {:keys [participant-id losingfn]
-                                      :or   {participant-id (str (UUID/randomUUID))
-                                             losingfn       (constantly nil)}}]
+  [curator-framework ^String path leaderfn & {:keys [participant-id losingfn]
+                                              :or   {participant-id (str (UUID/randomUUID))
+                                                     losingfn       (constantly nil)}}]
   {:pre [(.startsWith path "/") (not (nil? participant-id))]}
   (doto (LeaderSelector. curator-framework path (listener leaderfn losingfn participant-id))
     (.setId participant-id)
@@ -35,17 +35,17 @@
 
 (defn interrupt-leadership
   "Attempt to cancel current leadership if we currently have leadership"
-  [leader-selector]
+  [^LeaderSelector leader-selector]
   (.interruptLeadership leader-selector))
 
 (defn leader?
-  [leader-selector]
+  [^LeaderSelector leader-selector]
   (.hasLeadership leader-selector))
 
 (defn leader
-  [leader-selector]
+  [^LeaderSelector leader-selector]
   (.getLeader leader-selector))
 
 (defn participants
-  [leader-selector]
+  [^LeaderSelector leader-selector]
   (.getParticipants leader-selector))

--- a/src/curator/leader_latch.clj
+++ b/src/curator/leader_latch.clj
@@ -8,7 +8,7 @@
     (isLeader [this] (leaderfn))
     (notLeader [this] (notleaderfn))))
 
-(defn leader-latch
+(defn ^LeaderLatch leader-latch
   "Creates a Leader Latch.
  path: The path in ZooKeeper for storing this leadership group
  leaderfn: Function that will be called when the current process becomes
@@ -17,9 +17,9 @@
  notleaderfn: Optional function that will be called when the connection state
     changes and we are not the leader.
  participant-id: Uniquely identifies this participant. Defaults to UUID/randomUUID"
-  [curator-framework path leaderfn & {:keys [participant-id notleaderfn close-mode]
-                                      :or   {participant-id (str (UUID/randomUUID))
-                                             notleaderfn    (constantly nil)}}]
+  [curator-framework ^String path leaderfn & {:keys [participant-id notleaderfn close-mode]
+                                              :or   {participant-id (str (UUID/randomUUID))
+                                                     notleaderfn    (constantly nil)}}]
   {:pre [(.startsWith path "/") (not (nil? participant-id))]}
   (doto (LeaderLatch. curator-framework path participant-id (if (= :notify-leader close-mode)
                                                               LeaderLatch$CloseMode/NOTIFY_LEADER
@@ -27,13 +27,13 @@
     (.addListener (listener leaderfn notleaderfn))))
 
 (defn leader?
-  [leader-latch]
+  [^LeaderLatch leader-latch]
   (.hasLeadership leader-latch))
 
 (defn leader
-  [leader-latch]
+  [^LeaderLatch leader-latch]
   (.getLeader leader-latch))
 
 (defn participants
-  [leader-latch]
+  [^LeaderLatch leader-latch]
   (.getParticipants leader-latch))

--- a/src/curator/path_cache.clj
+++ b/src/curator/path_cache.clj
@@ -1,13 +1,14 @@
 (ns curator.path-cache
-  (:import (org.apache.curator.framework.recipes.cache PathChildrenCache PathChildrenCacheListener)))
+  (:import (org.apache.curator.framework.recipes.cache PathChildrenCache PathChildrenCacheListener)
+           (org.apache.curator.framework CuratorFramework)))
 
-(defn path-cache
+(defn ^PathChildrenCache path-cache
   "A Path Cache is used to watch a ZNode. Whenever a child is added, updated or removed, the Path Cache will change
   its state to contain the current set of children, the children's data and the children's state.
   client - the client
   path - path to watch
   listener-fn - a function that accepts 2 arguments, the curator framework and the PathChildrenCacheEvent that occured"
-  [curator-framework path listener-fn]
+  [^CuratorFramework curator-framework ^String path listener-fn]
   (let [cache (PathChildrenCache. curator-framework path true)
         listenable (.getListenable cache)]
     (.addListener listenable (reify PathChildrenCacheListener


### PR DESCRIPTION
Hi,

I suggest to upgrade to the latest available apache curator version 2.8.0. I'm mostly interested https://issues.apache.org/jira/browse/CURATOR-105 (Memory leak when using PathChildrenCache).

I've also added some type hints were needed to remove reflection usage.