### PR TITLE
Add support for Exhibitor Ensemble Provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,31 @@ A (work-in-progress) dummy application is being produced that uses the library t
 (.close client)
 ```
 
+## Exhibitor Ensemble provider
+
+```clojure
+(ns myservice
+  (:require [curator.framework :refer (curator-framework)]
+            [curator.exhibitor :refer (exhibitor-ensemble-provider exhibitors)]))
+
+;; exhibitor host
+(def exhibitor-hosts ["exhibitor-1" "exhibitor-2" "exhibitor-3"])
+
+(def exhibitor-port 8080)
+(def backup-connection-string "localhost:2181")
+
+(def provider (exhibitor-ensemble-provider
+                (exhibitors exhibitor-hosts
+                            exhibitor-port
+                            backup-connection-string))
+
+(.pollForInitialEnsemble provider)
+
+;; now we create the curator-framework client
+(def client (curator-framework "" :ensemble-provider provider))
+(.start client)
+```
+
 ## Leadership Election
 Leadership elections can be useful when you need to have multiple instances of a service/process and one of the designated as the leader/master/coordinator etc.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject curator "0.0.5"
+(defproject curator "0.1.0"
   :description "Clojurified Apache Curator"
   :url "https://github.com/pingles/curator"
   :license {:name "Eclipse Public License"

--- a/src/curator/exhibitor.clj
+++ b/src/curator/exhibitor.clj
@@ -1,0 +1,25 @@
+(ns curator.exhibitor
+  (:require [curator.framework :refer (exponential-retry)])
+  (:import [org.apache.curator.ensemble.exhibitor
+            Exhibitors
+            ExhibitorEnsembleProvider
+            DefaultExhibitorRestClient
+            Exhibitors$BackupConnectionStringProvider]))
+
+(defn ^ExhibitorEnsembleProvider exhibitor-ensemble-provider
+  [^Exhibitors exhibitors & {:keys [ rest-client uri polling-ms retry-policy ]
+                             :or   { rest-client (DefaultExhibitorRestClient.)
+                                    uri          "/exhibitor/v1/cluster/list"
+                                    polling-ms   (* 10 1000)
+                                    retry-policy (exponential-retry 1000 10) }}]
+  (ExhibitorEnsembleProvider. exhibitors rest-client uri polling-ms retry-policy))
+
+(defn backup-connection-provider [s]
+  (reify Exhibitors$BackupConnectionStringProvider
+    (getBackupConnectionString [this]
+      (str s))))
+
+(defn ^Exhibitors exhibitors
+  [hosts port backup-connection-string]
+  (Exhibitors. (java.util.ArrayList. hosts)
+               port (backup-connection-provider backup-connection-string)))


### PR DESCRIPTION
This PR add support for exhibitor ensemble provider.

Use .ensembleProvider method instead of .connectionString in curator-framework function. This will give use the ability to use other providers in the feature.
(docs here: http://curator.apache.org/apidocs/org/apache/curator/framework/CuratorFrameworkFactory.Builder.html#connectString-java.lang.String-)

