### PR TITLE
Fix first example in README's problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A (work-in-progress) dummy application is being produced that uses the library t
 ```clojure
 (ns myservice
   (:require [curator.framework :refer (curator-framework)]
-            [curator.discovery :refer (service-discovery service-instance service-provider instance instances services note-error round-robin-strategy)]))
+            [curator.discovery :refer (service-discovery service-instance service-provider instance instances services note-error round-robin-strategy service-cache)]))
 
 ;; services (and their instances) are registered by name
 (def service-name "some-service")
@@ -36,7 +36,7 @@ A (work-in-progress) dummy application is being produced that uses the library t
 ;; create an instance of our service. we don't specify address
 ;; so it'll use a public address from our network interfaces.
 ;; payloads must be strings for now
-(def instance (service-instance service-name
+(def inst (service-instance service-name
                                 "{scheme}://{address}:{port}"
                                 1234
                                 :payload "testing 123"))
@@ -48,7 +48,7 @@ A (work-in-progress) dummy application is being produced that uses the library t
 
 ;; next we create our service discovery, which uses the client
 ;; in the background to register our service instance
-(def discovery (service-discovery client instance :base-path "/foo"))
+(def discovery (service-discovery client inst :base-path "/foo"))
 (.start discovery)
 
 ;; now we can see which services are registered

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A (work-in-progress) dummy application is being produced that uses the library t
 ```clojure
 (ns myservice
   (:require [curator.framework :refer (curator-framework)]
-            [curator.discovery :refer (service-discovery service-instance service-provider instance instances services note-error)]))
+            [curator.discovery :refer (service-discovery service-instance service-provider instance instances services note-error round-robin-strategy)]))
 
 ;; services (and their instances) are registered by name
 (def service-name "some-service")


### PR DESCRIPTION
Fixed some issues with the first example in the README. 

`round-robin-strategy` and `service-cache` are used in the example, but not included in the :require of the example. 

`:require`d `instance` shadowed `def`d `instance` var, renamed to `inst`



