### PR TITLE
Now supporting arbitrary payload classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml.asc
 /.nrepl-port
 /.idea
 *.iml
+/bin/
+.classpath
+.project

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject curator "0.0.6"
+(defproject curator "1.0.0"
   :description "Clojurified Apache Curator"
   :url "https://github.com/pingles/curator"
   :license {:name "Eclipse Public License"

--- a/src/curator/discovery.clj
+++ b/src/curator/discovery.clj
@@ -1,6 +1,7 @@
 (ns ^{:doc "Namespace for service discovery"} curator.discovery
     (:require [clojure.edn :as edn]
-              [curator.framework :refer (time-units)])
+              [curator.framework :refer (time-units)]
+              [clojure.walk :refer (stringify-keys)])
     (:import [org.apache.curator.x.discovery ServiceDiscovery ServiceDiscoveryBuilder ServiceInstance ServiceType UriSpec ProviderStrategy DownInstancePolicy ServiceProvider ServiceCache]
              [org.apache.curator.x.discovery.details InstanceSerializer JsonInstanceSerializer InstanceProvider]
              [org.apache.curator.x.discovery.strategies RandomStrategy RoundRobinStrategy StickyStrategy]
@@ -29,14 +30,17 @@
   "name: my-service
    uri-spec: \"{scheme}://foo.com:{port}\"
    port: 1234
-   payload is serialized using json, only supports strings for now"
+   payload is serialized using json (if it is a clojure map, we do 
+              stringify-keys and transform it to a java hash map)."
   [name uri-spec port & {:keys [id address ssl-port service-type payload]}]
-  {:pre [(or (nil? payload) (string? payload))]}
   (let [service-types {:dynamic   ServiceType/DYNAMIC
                        :static    ServiceType/STATIC
                        :permanent ServiceType/PERMANENT}]
     (-> (dotonn (ServiceInstance/builder)
-                (.payload payload)
+                (.payload (if (map? payload)
+                            ;; if we got a clojure map, stringify keys in order to get nicer json output
+                            (java.util.HashMap. (stringify-keys payload))
+                            payload))
                 (.name name)
                 (.id id)
                 (.address address)
@@ -49,76 +53,95 @@
 (defn uri [^ServiceInstance service-instance]
   (.buildUriSpec service-instance))
 
-(defn json-serializer []
-  (JsonInstanceSerializer. String))
+(defn json-serializer [payload-class]
+  (let [serializer (JsonInstanceSerializer. payload-class)]
+    (reify org.apache.curator.x.discovery.details.InstanceSerializer 
+      (serialize [this instance]
+        (.serialize serializer instance))
+      (deserialize [this bytes]        
+        (if (= payload-class java.util.HashMap)
+          ;; if we have a hash map, convert to clojure map
+          (let [instance (.deserialize serializer bytes)
+                {:keys [name,  id,  address,  port,  sslPort, registrationTimeUTC,  serviceType,  
+                        uriSpec]} (bean instance)]
+            (org.apache.curator.x.discovery.ServiceInstance. name id address 
+              port sslPort 
+              (clojure.walk/keywordize-keys (into {} (.getPayload instance)))
+              registrationTimeUTC,  serviceType,  uriSpec))
+          (.deserialize serializer bytes))))))
+          
+  
 
-(defn ^ServiceDiscovery service-discovery
-  [curator-framework service-instance & {:keys [base-path serializer payload-class]
-                                         :or   {base-path     "/foo"
-                                                payload-class String
-                                                serializer    (json-serializer)}}]
-  {:pre [(.startsWith ^String base-path "/")]}
-  (-> (dotonn (ServiceDiscoveryBuilder/builder payload-class)
-              (.client curator-framework)
-              (.basePath base-path)
-              (.serializer (json-serializer))
-              (.thisInstance service-instance))
-      (.build)))
+  (defn ^ServiceDiscovery service-discovery
+    "base-path [/foo] 
+   payload-class [HashMap]
+   serializer [JsonInstanceSerializer (HashMap)]"
+    [curator-framework service-instance & {:keys [base-path serializer payload-class]
+                                           :or   {base-path     "/foo"
+                                                  payload-class java.util.HashMap
+                                                  serializer    (json-serializer java.util.HashMap)}}]
+    {:pre [(.startsWith ^String base-path "/")]}
+    (-> (dotonn (ServiceDiscoveryBuilder/builder payload-class)
+                (.client curator-framework)
+                (.basePath base-path)
+                (.serializer serializer)
+                (.thisInstance service-instance))
+        (.build)))
 
-(defn services
-  "Returns the names of the services registered."
-  [^ServiceDiscovery service-discovery]
-  (.queryForNames service-discovery))
+  (defn services
+    "Returns the names of the services registered."
+    [^ServiceDiscovery service-discovery]
+    (.queryForNames service-discovery))
 
-(defn random-strategy
-  []
-  (RandomStrategy. ))
+  (defn random-strategy
+    []
+    (RandomStrategy. ))
 
-(defn round-robin-strategy
-  []
-  (RoundRobinStrategy. ))
+  (defn round-robin-strategy
+    []
+    (RoundRobinStrategy. ))
 
-(defn sticky-strategy
-  [^ProviderStrategy strategy]
-  (StickyStrategy. strategy))
+  (defn sticky-strategy
+    [^ProviderStrategy strategy]
+    (StickyStrategy. strategy))
 
 
-(defn down-instance-policy
-  ([] (down-instance-policy 30 :seconds 2))
-  ([timeout timeout-unit error-threshold]
-     {:pre [(some time-units [timeout-unit])]}
-     (DownInstancePolicy. timeout (time-units timeout-unit) error-threshold)))
+  (defn down-instance-policy
+    ([] (down-instance-policy 30 :seconds 2))
+    ([timeout timeout-unit error-threshold]
+       {:pre [(some time-units [timeout-unit])]}
+       (DownInstancePolicy. timeout (time-units timeout-unit) error-threshold)))
 
-(defn ^ServiceProvider service-provider
-  "Creates a service provider for a named service s."
-  [^ServiceDiscovery service-discovery s & {:keys [strategy down-instance-policy]
-                                            :or   {strategy             (random-strategy)
-                                                   down-instance-policy (down-instance-policy)}}]
-  (-> (doto (.serviceProviderBuilder service-discovery)
-        (.serviceName s)
-        (.downInstancePolicy down-instance-policy)
-        (.providerStrategy strategy))
-      (.build)))
+  (defn ^ServiceProvider service-provider
+    "Creates a service provider for a named service s."
+    [^ServiceDiscovery service-discovery s & {:keys [strategy down-instance-policy]
+                                              :or   {strategy             (random-strategy)
+                                                     down-instance-policy (down-instance-policy)}}]
+    (-> (doto (.serviceProviderBuilder service-discovery)
+          (.serviceName s)
+          (.downInstancePolicy down-instance-policy)
+          (.providerStrategy strategy))
+        (.build)))
 
-(defn service-cache
-  "Creates a service cache (rather than reading ZooKeeper each time) for
+  (defn service-cache
+    "Creates a service cache (rather than reading ZooKeeper each time) for
    the service named s"
-  [^ServiceDiscovery service-discovery s]
-  (-> (.serviceCacheBuilder service-discovery)
-      ( .name s)
-      (.build)))
+    [^ServiceDiscovery service-discovery s]
+    (-> (.serviceCacheBuilder service-discovery)
+        ( .name s)
+        (.build)))
 
-(defn note-error
-  "Clients should use this to indicate a problem when trying to
+  (defn note-error
+    "Clients should use this to indicate a problem when trying to
    connect to a service instance. The instance may be marked as down
    depending on the service provider's down instance policy."
-  [^ServiceProvider service-provider ^ServiceInstance instance]
-  (.noteError service-provider instance))
+    [^ServiceProvider service-provider ^ServiceInstance instance]
+    (.noteError service-provider instance))
 
-(defmulti instances (fn [^Object x & args] (.getClass x)))
-(defmethod instances ServiceDiscovery [^ServiceDiscovery sd s] (.queryForInstances sd s))
-(defmethod instances ServiceCache [^ServiceCache sc] (.getInstances sc))
+  (defmulti instances (fn [^Object x & args] (.getClass x)))
+  (defmethod instances ServiceDiscovery [^ServiceDiscovery sd s] (.queryForInstances sd s))
+  (defmethod instances ServiceCache [^ServiceCache sc] (.getInstances sc))
 
-(defmulti instance (fn [^Object x & args] (.getClass x)))
-(defmethod instance ServiceProvider [^ServiceProvider provider] (.getInstance provider))
-(defmethod instance ServiceCache [cache ^ProviderStrategy strategy] (.getInstance strategy cache))
+  (defmulti instance (fn [^Object x & args] (.getClass x)))
+  (defmethod instance ServiceProvider [^ServiceProvider provider] (.getInstance provider))
+  (defmethod instance ServiceCache [cache ^ProviderStrategy strategy] (.getInstance strategy cache))


### PR DESCRIPTION
* The default payload class is now a clojure map
* You can pass any other type as well, but in that case, you will have to
  provide your own (de)serializer and the payload-class when invoking
  service-discovery.
* Clojure maps are converted to Java Hashmaps to get nicer JSON output
* This breaks compatibility with the previous version where String was
  accepted as payload