### PR TITLE
Upgrade to curator 3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ A (work-in-progress) dummy application is being produced that uses the library t
 (def provider (exhibitor-ensemble-provider
                 (exhibitors exhibitor-hosts
                             exhibitor-port
-                            backup-connection-string))
+                            backup-connection-string)))
 
 (.pollForInitialEnsemble provider)
 

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.curator/curator-recipes "2.8.0"]
-                 [org.apache.curator/curator-framework "2.8.0"]
-                 [org.apache.curator/curator-x-discovery "2.8.0"]]
-  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.12"]
-                                  [org.slf4j/slf4j-simple "1.7.12"]]
+                 [org.apache.curator/curator-recipes "3.2.1"]
+                 [org.apache.curator/curator-framework "3.2.1"]
+                 [org.apache.curator/curator-x-discovery "3.2.1"]]
+  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.24"]
+                                  [org.slf4j/slf4j-simple "1.7.24"]]
                    :exclusions [org.slf4j/slf4j-log4j12]}}
   :scm {:name "git"
         :url "https://github.com/pingles/curator"})

--- a/src/curator/exhibitor.clj
+++ b/src/curator/exhibitor.clj
@@ -4,7 +4,8 @@
             Exhibitors
             ExhibitorEnsembleProvider
             DefaultExhibitorRestClient
-            Exhibitors$BackupConnectionStringProvider]))
+            Exhibitors$BackupConnectionStringProvider]
+           (java.util List ArrayList)))
 
 (defn ^ExhibitorEnsembleProvider exhibitor-ensemble-provider
   [^Exhibitors exhibitors & {:keys [rest-client uri polling-ms retry-policy ]
@@ -20,7 +21,7 @@
       connection-string)))
 
 (defn ^Exhibitors exhibitors
-  [hosts port backup-connection-string]
-  (Exhibitors. (java.util.ArrayList. hosts)
+  [^List hosts port backup-connection-string]
+  (Exhibitors. (ArrayList. hosts)
                port
                (backup-connection-provider backup-connection-string)))


### PR DESCRIPTION
Hi,

Here is a PR to upgrade to curator 3.2.1 which introduce quite a few improvements and bugfixes.

Also, I've removed a reflection warning within `curator.exhibitor` :-)