### PR TITLE
Add constructor for non-reentrant mutex

### DIFF
--- a/src/curator/mutex.clj
+++ b/src/curator/mutex.clj
@@ -1,6 +1,6 @@
 (ns curator.mutex
   (:import
-    [org.apache.curator.framework.recipes.locks InterProcessMutex]
+    [org.apache.curator.framework.recipes.locks InterProcessMutex InterProcessSemaphoreMutex]
     [org.apache.curator.framework CuratorFramework]
     [java.util.concurrent TimeUnit]))
 
@@ -9,14 +9,19 @@
   [^CuratorFramework client ^String path]
   (InterProcessMutex. client path))
 
+(defn ^InterProcessSemaphoreMutex semaphore-mutex
+  "Create an InterProcessSemaphoreMutex. This mutex is not re-entrant."
+  [^CuratorFramework client ^String path]
+  (InterProcessSemaphoreMutex. client path))
+
 (defn acquire
   "If no timeunits are given, blocks until acquired. Otherwise returns true or
    false depending on if it acquires the lock in the given time. Time defaults
    to milliseconds."
-  ([^InterProcessMutex m] (.acquire m))
-  ([^InterProcessMutex m ^long n] (.acquire m n TimeUnit/MILLISECONDS))
-  ([^InterProcessMutex m ^long n ^TimeUnit tu] (.acquire m n tu)))
+  ([m] (.acquire m))
+  ([m ^long n] (.acquire m n TimeUnit/MILLISECONDS))
+  ([m ^long n ^TimeUnit tu] (.acquire m n tu)))
 
 (defn release
   "Release a mutex."
-  [^InterProcessMutex m] (.release m))
+  [m] (.release m))


### PR DESCRIPTION
Allow constructing InterProcessSemaphoreMutex when reentrant mutexes are not desired.