### PR TITLE
Switch back to curator 2.13.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.curator/curator-recipes "3.2.1"]
-                 [org.apache.curator/curator-framework "3.2.1"]
-                 [org.apache.curator/curator-x-discovery "3.2.1"]]
+                 [org.apache.curator/curator-recipes "2.12.0"]
+                 [org.apache.curator/curator-framework "2.12.0"]
+                 [org.apache.curator/curator-x-discovery "2.12.0"]]
   :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.24"]
                                   [org.slf4j/slf4j-simple "1.7.24"]]
                    :exclusions [org.slf4j/slf4j-log4j12]}}

--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,11 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.apache.curator/curator-recipes "2.12.0"]
-                 [org.apache.curator/curator-framework "2.12.0"]
-                 [org.apache.curator/curator-x-discovery "2.12.0"]]
-  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.24"]
-                                  [org.slf4j/slf4j-simple "1.7.24"]]
+                 [org.apache.curator/curator-recipes "2.13.0"]
+                 [org.apache.curator/curator-framework "2.13.0"]
+                 [org.apache.curator/curator-x-discovery "2.13.0"]]
+  :profiles {:dev {:dependencies [[org.slf4j/log4j-over-slf4j "1.7.30"]
+                                  [org.slf4j/slf4j-simple "1.7.30"]]
                    :exclusions [org.slf4j/slf4j-log4j12]}}
   :scm {:name "git"
         :url "https://github.com/pingles/curator"})


### PR DESCRIPTION
Replace #9 .

Curator version 3.x targets Zookeeper 3.5 which is in alpha. Using this version on an ensemble running Zookeeper 3.4 may lead to protocol incompatibilities.